### PR TITLE
(tenatively) adding testthat for as_api_object -- need to check arguments?

### DIFF
--- a/R/as.R
+++ b/R/as.R
@@ -4,7 +4,7 @@
 #'
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams rlang::args_error_context
-#' @param x The object to coerce. Must be empty or have names corresponding to
+#' @param x The named list to coerce. Must be empty or have names corresponding to
 #'   the parameter of the `target_class`, or names that can be coerced to those
 #'   names via [snakecase::to_snake_case()]. Extra names are ignored.
 #' @param target_class The S7 class to which the object should be converted.

--- a/R/as.R
+++ b/R/as.R
@@ -1,12 +1,13 @@
 #' Convert to a rapid-style object
 #'
-#' Convert a named list into an object with a rapid-style class.
+#' Convert an object into an object with a rapid-style class.
 #'
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams rlang::args_error_context
-#' @param x The named list to coerce. Must be empty or have names corresponding to
-#'   the parameter of the `target_class`, or names that can be coerced to those
-#'   names via [snakecase::to_snake_case()]. Extra names are ignored.
+#' @param x The object to coerce. Must be empty, or be a named list or character
+#'   vector having names corresponding to the parameter of the `target_class`,
+#'   or names that can be coerced to those names via
+#'   [snakecase::to_snake_case()]. Extra names are ignored.
 #' @param target_class The S7 class to which the object should be converted.
 #' @param alternate_names Character vector (optional). An optional named
 #'   character vector, where the names are the names as they might appear in

--- a/man/as_api_object.Rd
+++ b/man/as_api_object.Rd
@@ -14,9 +14,10 @@ as_api_object(
 )
 }
 \arguments{
-\item{x}{The object to coerce. Must be empty or have names corresponding to
-the parameter of the \code{target_class}, or names that can be coerced to those
-names via \code{\link[snakecase:caseconverter]{snakecase::to_snake_case()}}. Extra names are ignored.}
+\item{x}{The object to coerce. Must be empty, or be a named list or character
+vector having names corresponding to the parameter of the \code{target_class},
+or names that can be coerced to those names via
+\code{\link[snakecase:caseconverter]{snakecase::to_snake_case()}}. Extra names are ignored.}
 
 \item{target_class}{The S7 class to which the object should be converted.}
 
@@ -39,5 +40,5 @@ mentioned in error messages as the source of the error. See the
 An object with the specified \code{target_class}.
 }
 \description{
-Convert a named list into an object with a rapid-style class.
+Convert an object into an object with a rapid-style class.
 }

--- a/tests/testthat/test-as.R
+++ b/tests/testthat/test-as.R
@@ -1,0 +1,10 @@
+test_that("as_api_object() checks argument `x` ", {
+  expect_error(as_api_object())
+  expect_error(as_api_object(NULL))
+  expect_error(as_api_object(list()))
+
+  L <- list(a = "one") # named list
+  M <- c(a = "one") # named character vector
+  expect_error(as_api_object(L))
+  expect_error(as_api_object(M))
+})


### PR DESCRIPTION
`as_api_object`  does not check `x` is valid.