### PR TITLE
Work around tibblify bugs for paths.

### DIFF
--- a/R/urls.R
+++ b/R/urls.R
@@ -15,3 +15,7 @@
     }
   )
 }
+
+.is_url_string <- function(x) {
+  grepl("^https?://", x)
+}


### PR DESCRIPTION
"Apply" response schemas supplied as URLs, and fill in missing pieces to make tibblify happy. Also check to make sure the necessary version of tibblify is installed.

Closes #95.